### PR TITLE
Authenticate SSH via LDAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ not built by default and will require a retag from a maintainer to be built.
         --https-address=:443 \
         --https=true \
         --https-certificate-directory=/ssl \
-        --authentication-keys-directory=/pubkeys \
         --private-key-location=/keys/ssh_key \
         --bind-random-ports=false
       ```
@@ -144,23 +143,7 @@ ssh -J ssi.sh mylaptop
 
 ## Authentication
 
-If you want to use this service privately, it supports both public key and password
-authentication. To enable authentication, set `--authentication=true` as one of your CLI
-options and be sure to configure `--authentication-keys-directory` to your
-liking. The directory provided by `--authentication-keys-directory` is watched for changes and will reload
-the authorized keys automatically. The authorized cert index is regenerated on directory
-modification, so removed public keys will also automatically be removed. Files in this
-directory can either be single key per file, or multiple keys per file separated by newlines,
-similar to `authorized_keys`.
-
-One of my favorite ways of using this for authentication is like so:
-
-```bash
-sish@sish0:~/sish/pubkeys# curl https://github.com/antoniomika.keys > antoniomika
-```
-
-This will load my public keys from GitHub, place them in the directory that sish is watching,
-and then load the pubkey. As soon as this command is run, I can SSH normally and it will authorize me.
+We use LDAP to fetch public key for given user name then use it to authenticate.
 
 ## Custom domains
 
@@ -271,9 +254,6 @@ Flags:
       --append-user-to-subdomain                    Append the SSH user to the subdomain. This is useful in multitenant environments
       --append-user-to-subdomain-separator string   The token to use for separating username and subdomain selection in a virtualhost (default "-")
       --authentication                              Require authentication for the SSH service
-  -k, --authentication-keys-directory string        Directory where public keys for public key authentication are stored.
-                                                    sish will watch this directory and automatically load new keys and remove keys
-                                                    from the authentication list (default "deploy/pubkeys/")
       --banned-aliases string                       A comma separated list of banned aliases that users are unable to bind
   -o, --banned-countries string                     A comma separated list of banned countries. Applies to HTTP, TCP, and SSH connections
   -x, --banned-ips string                           A comma separated list of banned ips that are unable to access the service. Applies to HTTP, TCP, and SSH connections

--- a/README.md
+++ b/README.md
@@ -146,13 +146,12 @@ ssh -J ssi.sh mylaptop
 
 If you want to use this service privately, it supports both public key and password
 authentication. To enable authentication, set `--authentication=true` as one of your CLI
-options and be sure to configure `--authentication-password` or `--authentication-keys-directory` to your
+options and be sure to configure `--authentication-keys-directory` to your
 liking. The directory provided by `--authentication-keys-directory` is watched for changes and will reload
 the authorized keys automatically. The authorized cert index is regenerated on directory
 modification, so removed public keys will also automatically be removed. Files in this
 directory can either be single key per file, or multiple keys per file separated by newlines,
-similar to `authorized_keys`. Password auth can be disabled by setting `--authentication-password=""` as a
-CLI option.
+similar to `authorized_keys`.
 
 One of my favorite ways of using this for authentication is like so:
 
@@ -275,7 +274,6 @@ Flags:
   -k, --authentication-keys-directory string        Directory where public keys for public key authentication are stored.
                                                     sish will watch this directory and automatically load new keys and remove keys
                                                     from the authentication list (default "deploy/pubkeys/")
-  -u, --authentication-password string              Password to use for ssh server password authentication (default "S3Cr3tP4$$W0rD")
       --banned-aliases string                       A comma separated list of banned aliases that users are unable to bind
   -o, --banned-countries string                     A comma separated list of banned countries. Applies to HTTP, TCP, and SSH connections
   -x, --banned-ips string                           A comma separated list of banned ips that are unable to access the service. Applies to HTTP, TCP, and SSH connections

--- a/cmd/sish.go
+++ b/cmd/sish.go
@@ -63,7 +63,6 @@ func init() {
 	rootCmd.PersistentFlags().StringP("whitelisted-countries", "y", "", "A comma separated list of whitelisted countries. Applies to HTTP, TCP, and SSH connections")
 	rootCmd.PersistentFlags().StringP("private-key-passphrase", "p", "S3Cr3tP4$$phrAsE", "Passphrase to use to encrypt the server private key")
 	rootCmd.PersistentFlags().StringP("private-key-location", "l", "deploy/keys/ssh_key", "The location of the SSH server private key. sish will create a private key here if\nit doesn't exist using the --private-key-passphrase to encrypt it if supplied")
-	rootCmd.PersistentFlags().StringP("authentication-password", "u", "S3Cr3tP4$$W0rD", "Password to use for ssh server password authentication")
 	rootCmd.PersistentFlags().StringP("authentication-keys-directory", "k", "deploy/pubkeys/", "Directory where public keys for public key authentication are stored.\nsish will watch this directory and automatically load new keys and remove keys\nfrom the authentication list")
 	rootCmd.PersistentFlags().StringP("port-bind-range", "n", "0,1024-65535", "Ports or port ranges that sish will allow to be bound when a user attempts to use TCP forwarding")
 	rootCmd.PersistentFlags().StringP("proxy-protocol-version", "q", "1", "What version of the proxy protocol to use. Can either be 1, 2, or userdefined.\nIf userdefined, the user needs to add a command to SSH called proxyproto:version (ie proxyproto:1)")

--- a/cmd/sish.go
+++ b/cmd/sish.go
@@ -63,7 +63,6 @@ func init() {
 	rootCmd.PersistentFlags().StringP("whitelisted-countries", "y", "", "A comma separated list of whitelisted countries. Applies to HTTP, TCP, and SSH connections")
 	rootCmd.PersistentFlags().StringP("private-key-passphrase", "p", "S3Cr3tP4$$phrAsE", "Passphrase to use to encrypt the server private key")
 	rootCmd.PersistentFlags().StringP("private-key-location", "l", "deploy/keys/ssh_key", "The location of the SSH server private key. sish will create a private key here if\nit doesn't exist using the --private-key-passphrase to encrypt it if supplied")
-	rootCmd.PersistentFlags().StringP("authentication-keys-directory", "k", "deploy/pubkeys/", "Directory where public keys for public key authentication are stored.\nsish will watch this directory and automatically load new keys and remove keys\nfrom the authentication list")
 	rootCmd.PersistentFlags().StringP("port-bind-range", "n", "0,1024-65535", "Ports or port ranges that sish will allow to be bound when a user attempts to use TCP forwarding")
 	rootCmd.PersistentFlags().StringP("proxy-protocol-version", "q", "1", "What version of the proxy protocol to use. Can either be 1, 2, or userdefined.\nIf userdefined, the user needs to add a command to SSH called proxyproto:version (ie proxyproto:1)")
 	rootCmd.PersistentFlags().StringP("proxy-protocol-policy", "", "use", "What to do with the proxy protocol header. Can be use, ignore, reject, or require")

--- a/config.example.yml
+++ b/config.example.yml
@@ -5,7 +5,6 @@ append-user-to-subdomain: false
 append-user-to-subdomain-separator: '-'
 authentication: false
 authentication-keys-directory: deploy/pubkeys/
-authentication-password: S3Cr3tP4$$W0rD
 banned-aliases: ""
 banned-countries: ""
 banned-ips: ""

--- a/config.example.yml
+++ b/config.example.yml
@@ -4,7 +4,6 @@ alias-load-balancer: false
 append-user-to-subdomain: false
 append-user-to-subdomain-separator: '-'
 authentication: false
-authentication-keys-directory: deploy/pubkeys/
 banned-aliases: ""
 banned-countries: ""
 banned-ips: ""

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   sish:
     image: antoniomika/sish:latest
     container_name: sish
-    depends_on: 
+    depends_on:
       - letsencrypt
     volumes:
       - ./letsencrypt:/etc/letsencrypt
@@ -25,7 +25,6 @@ services:
       --https-address=:443
       --https=true
       --https-certificate-directory=/ssl
-      --authentication-keys-directory=/pubkeys
       --private-key-location=/keys/ssh_key
       --bind-random-ports=false
       --bind-random-subdomains=false

--- a/sshmuxer/sshmuxer.go
+++ b/sshmuxer/sshmuxer.go
@@ -58,8 +58,6 @@ func Start() {
 		httpsPort = viper.GetInt("https-port-override")
 	}
 
-	utils.WatchCerts()
-
 	state := utils.NewState()
 	state.Console.State = state
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -304,15 +304,6 @@ func loadCerts() {
 func GetSSHConfig() *ssh.ServerConfig {
 	sshConfig := &ssh.ServerConfig{
 		NoClientAuth: !viper.GetBool("authentication"),
-		PasswordCallback: func(c ssh.ConnMetadata, password []byte) (*ssh.Permissions, error) {
-			log.Printf("Login attempt: %s, user %s", c.RemoteAddr(), c.User())
-
-			if string(password) == viper.GetString("authentication-password") && viper.GetString("authentication-password") != "" {
-				return nil, nil
-			}
-
-			return nil, fmt.Errorf("password doesn't match")
-		},
 		PublicKeyCallback: func(c ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
 			log.Printf("Login attempt: %s, user %s key: %s", c.RemoteAddr(), c.User(), string(ssh.MarshalAuthorizedKey(key)))
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -41,12 +41,6 @@ var (
 	// Filter is the IPFilter used to block connections.
 	Filter *ipfilter.IPFilter
 
-	// certHolder is a slice of publickeys for auth.
-	certHolder = make([]ssh.PublicKey, 0)
-
-	// holderLock is the mutex used to update the certHolder slice.
-	holderLock = sync.Mutex{}
-
 	// bannedSubdomainList is a list of subdomains that cannot be bound.
 	bannedSubdomainList = []string{""}
 
@@ -220,85 +214,6 @@ func CheckPort(port uint32, portRanges string) (uint32, error) {
 	return 0, fmt.Errorf("not a safe port")
 }
 
-// WatchCerts watches ssh keys for changes and will load them.
-func WatchCerts() {
-	loadCerts()
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	go func() {
-		c := make(chan os.Signal, 1)
-		signal.Notify(c, os.Interrupt)
-		go func() {
-			for range c {
-				watcher.Close()
-				os.Exit(0)
-			}
-		}()
-
-		for {
-			select {
-			case _, ok := <-watcher.Events:
-				if !ok {
-					return
-				}
-				loadCerts()
-			case _, ok := <-watcher.Errors:
-				if !ok {
-					return
-				}
-			}
-		}
-	}()
-
-	err = watcher.Add(viper.GetString("authentication-keys-directory"))
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
-// loadCerts loads public keys from the keys directory into a slice that is used
-// authenticating a user.
-func loadCerts() {
-	tmpCertHolder := make([]ssh.PublicKey, 0)
-
-	files, err := ioutil.ReadDir(viper.GetString("authentication-keys-directory"))
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	parseKey := func(keyBytes []byte, fileInfo os.FileInfo) {
-		keyHandle := func(keyBytes []byte, fileInfo os.FileInfo) []byte {
-			key, _, _, rest, e := ssh.ParseAuthorizedKey(keyBytes)
-			if e != nil {
-				log.Printf("Can't load file %s as public key: %s\n", fileInfo.Name(), e)
-			}
-
-			if key != nil {
-				tmpCertHolder = append(tmpCertHolder, key)
-			}
-			return rest
-		}
-
-		for ok := true; ok; ok = len(keyBytes) > 0 {
-			keyBytes = keyHandle(keyBytes, fileInfo)
-		}
-	}
-
-	for _, f := range files {
-		i, e := ioutil.ReadFile(filepath.Join(viper.GetString("authentication-keys-directory"), f.Name()))
-		if e == nil && len(i) > 0 {
-			parseKey(i, f)
-		}
-	}
-
-	holderLock.Lock()
-	defer holderLock.Unlock()
-	certHolder = tmpCertHolder
-}
-
 // GetSSHConfig Returns an SSH config for the ssh muxer.
 // It handles auth and storing user connection information.
 func GetSSHConfig() *ssh.ServerConfig {
@@ -307,8 +222,7 @@ func GetSSHConfig() *ssh.ServerConfig {
 		PublicKeyCallback: func(c ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
 			log.Printf("Login attempt: %s, user %s key: %s", c.RemoteAddr(), c.User(), string(ssh.MarshalAuthorizedKey(key)))
 
-			holderLock.Lock()
-			defer holderLock.Unlock()
+
 			for _, i := range certHolder {
 				if bytes.Equal(key.Marshal(), i.Marshal()) {
 					permssionsData := &ssh.Permissions{


### PR DESCRIPTION
In order for this to work, these 2 commands must work on the instance:

1. `/usr/bin/sss_ssh_authorizedkeys quanqchau` : This gives the authorized public keys of user
2. `groups quanqchau` : This gives the group the user belongs to

To set these up, look into https://github.com/appfolio/search_app/blob/ce6eebef78934bcae708dde9484920adf82ed852/terraform/tf_modules/ldap_setup_script/ldap_setup_script.tpl

We only allow group `qa` or group `developer` on LDAP to access this.
